### PR TITLE
Fix Row Iterator

### DIFF
--- a/ExcelParser.php
+++ b/ExcelParser.php
@@ -341,6 +341,7 @@ class ExcelParser extends BaseObject {
         $cellIterator = $row->getCellIterator();
         try {
             $cellIterator->setIterateOnlyExistingCells(TRUE);
+            $cellIterator->rewind();
         }
         catch (PhpSpreadsheetException $e) {
             // this happens when row is empty


### PR DESCRIPTION
Agregando el `rewind()` antes de iterar nos aseguramos de que el iterador sea valido